### PR TITLE
NN-977 Regression - error navigating to myKeyWorkerAllocations screen 

### DIFF
--- a/server/services/keyworker.js
+++ b/server/services/keyworker.js
@@ -53,6 +53,9 @@ const keyworkerServiceFactory = (eliteApi, keyworkerApi) => {
   };
 
   const offendersLastKWSession = async (context, offenders = []) => {
+    if (offenders.length === 0) {
+      return [];
+    }
     const offenderNumbers = offenders.map(offender => offender.offenderNo);
     const caseNotes = await eliteApi.caseNoteUsageList(context, offenderNumbers) || [];
 


### PR DESCRIPTION
Need to avoid passing an empty array to the api when the KW has no offenders.

Actually other endpoints eg CSRAs dont complain about this so a bit inconsistent.