### PR TITLE
NN-1099 Live / Regression - Key Dates screen no longer displaying ARD…

### DIFF
--- a/server/api/eliteApi.js
+++ b/server/api/eliteApi.js
@@ -8,6 +8,13 @@ const eliteApiFactory = (client) => {
     return response.data;
   };
 
+  const map404ToNull = error => {
+    if (!error.response) throw error;
+    if (!error.response.status) throw error;
+    if (error.response.status !== 404) throw error; // Not Found
+    return null;
+  };
+
   const get = (context, url) =>
     client
       .get(context, url)
@@ -38,7 +45,7 @@ const eliteApiFactory = (client) => {
   const getAssignedOffenders = (context) => get(context, 'api/users/me/bookingAssignments');
   const getAssessments = (context, bookingId) => get(context, `api/bookings/${bookingId}/assessments`);
   const getBalances = (context, bookingId) => get(context, `api/bookings/${bookingId}/balances`);
-  const getCategoryAssessment = (context, bookingId) => get(context, `api/bookings/${bookingId}/assessment/CATEGORY`);
+  const getCategoryAssessment = (context, bookingId) => get(context, `api/bookings/${bookingId}/assessment/CATEGORY`).catch(map404ToNull);
   const getContacts = (context, bookingId) => get(context, `api/bookings/${bookingId}/contacts`);
   const getDetails = (context, offenderNo) => get(context, `api/bookings/offenderNo/${offenderNo}?fullInfo=true`);
   const getDetailsLight = (context, offenderNo) => get(context, `api/bookings/offenderNo/${offenderNo}?fullInfo=false`);

--- a/tests/api/eliteApi.test.js
+++ b/tests/api/eliteApi.test.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const { expect, assert } = require('chai');
 const MockAdapter = require('axios-mock-adapter');
 const clientFactory = require('../../server/api/oauthEnabledClient');
 const eliteApiFactory = require('../../server/api/eliteApi').eliteApiFactory;
@@ -44,5 +44,23 @@ describe('eliteApi tests', () => {
   it('Sends post data', async () => {
     axiosMock.onPost('/test', { test: 'test' }).reply(200, {});
     await eliteApi.post({}, '/test', { test: 'test' });
-  })
+  });
+
+  it('Maps a GET assessment/CATEGORY response status of 404 to a null response', async () => {
+    axiosMock.onGet('api/bookings/1234/assessment/CATEGORY').reply(404);
+    const result = await eliteApi.getCategoryAssessment({}, 1234);
+    expect(result).to.be.null;
+  });
+
+  it('throws an exception for a GET assessment/CATEGORY response status of 401 ', async () => {
+    axiosMock.onGet('api/bookings/1234/assessment/CATEGORY').reply(401);
+
+    try {
+      await eliteApi.getCategoryAssessment({}, 1234);
+    } catch (error) {
+      // OK
+      return;
+    }
+    assert.fail(0,1, 'Expected 401 status to result in a throw');
+  });
 });


### PR DESCRIPTION
… (and possibly other) dates. Handle 404 response for getCategoryAssessment.