### PR TITLE
NN-1265 healthcheck returns 200 and "UP" even when downstream api is …

### DIFF
--- a/server/apiproxy.js
+++ b/server/apiproxy.js
@@ -14,6 +14,7 @@ function getAppInfo() {
     name: packageData.name,
     version: buildVersion,
     description: packageData.description,
+    status: 'UP',
   };
 }
 


### PR DESCRIPTION
…returning a non-success http status