### PR TITLE
NN-1285 Removed some overrides but allowed specific exceptions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,11 +34,10 @@
     "react/forbid-prop-types": 0,
     "react/prop-types": 0,
     "no-param-reassign": 0,
+    "import/no-named-as-default": 0, // disable as we use connected components
     "no-buffer-constructor": 0,
     "react/no-string-refs": 0,
     "prefer-promise-reject-errors": 0,
-    "react/style-prop-object": 0,
-    "import/no-webpack-loader-syntax": 0,
     "import/no-dynamic-require": 0
   },
   "plugins": ["prettier"]

--- a/app/app.js
+++ b/app/app.js
@@ -5,12 +5,11 @@
  * code.
  */
 // Load the favicon, the manifest.json file and the .htaccess file
-// eslint-disable-next-line import/no-unresolved
+/* eslint-disable */
 import '!file-loader?name=[name].[ext]!./favicon.ico'
-// eslint-disable-next-line import/no-unresolved
 import '!file-loader?name=[name].[ext]!./manifest.json'
-// eslint-disable-next-line import/no-unresolved
 import 'file-loader?name=[name].[ext]!./.htaccess'
+/* eslint-enable */
 
 // Needed for redux-saga es6 generator support
 import 'babel-polyfill'
@@ -23,14 +22,12 @@ import { applyRouterMiddleware, Router, browserHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import { useScroll } from 'react-router-scroll'
 
-// eslint-disable-next-line import/no-named-as-default
 import App from './containers/App'
 
 // Import selector for `syncHistoryWithStore`
 import makeSelectLocationState from './containers/App/selectors'
 
 // Import Language Provider
-// eslint-disable-next-line import/no-named-as-default
 import LanguageProvider from './containers/LanguageProvider'
 
 // Import reset css

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -14,7 +14,6 @@ import Breadcrumbs from '../Breadcrumbs'
 import Footer from '../Footer'
 import Spinner from '../../components/Spinner'
 import Terms from '../Footer/terms-and-conditions'
-// eslint-disable-next-line import/no-named-as-default
 import FeedbackLink from '../FeedbackLink'
 
 import { setAppConfig, setDeviceFormat, setMenuOpen, hideTerms } from '../../globalReducers/app'

--- a/app/containers/Bookings/Details/QuickLook/index.js
+++ b/app/containers/Bookings/Details/QuickLook/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/style-prop-object */
 import React, { Component } from 'react'
 import { FormattedNumber } from 'react-intl'
 import { connect } from 'react-redux'

--- a/app/containers/Bookings/Details/QuickLook/tests/balances.test.js
+++ b/app/containers/Bookings/Details/QuickLook/tests/balances.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/style-prop-object */
 import React from 'react'
 import { shallow } from 'enzyme'
 import { FormattedNumber } from 'react-intl'


### PR DESCRIPTION
- Removed react/style-prop-object override but disabled it where react-intl is used because they require the style param
- Removed import/no-webpack-loader-syntax override but it is used in 3 places in one file (`app/app.js`) so disabled that specifically for now
- Reintroduced import/no-named-as-default override and remove specific comments related to this.  Think we're going to continue to run into this problem otherwise because we export connected components