### PR TITLE
Fix intermitten out of memory error when building on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Run Tests
           command: |
              set -e
-             yarn test --maxWorkers=4
+             yarn test --maxWorkers=2
       - run: export CLIENT=hmpps && NODE_ENV=production yarn build
       - run: |
              DATE=$(date '+%Y-%m-%d')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Run Tests
           command: |
              set -e
-             yarn test
+             yarn test --maxWorkers=4
       - run: export CLIENT=hmpps && NODE_ENV=production yarn build
       - run: |
              DATE=$(date '+%Y-%m-%d')


### PR DESCRIPTION
When running the build-test-and-deploy workflow on Circle CI the build step sometimes fails with a `Failure message:
 ENOMEM: not enough memory, read` error (e.g https://circleci.com/gh/ministryofjustice/new-nomis-ui/2805). According to the [Jest documentation](https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server), this is a known issue with running Jest tests on CI platforms. 

This is implementing the approach recommended for a small amount of CPU cores which matches our Circle setup.