### PR TITLE
NN-1828 Prisoner image aspect ratio corrected and linter now detectin…

### DIFF
--- a/app/containers/Bookings/Details/index.scss
+++ b/app/containers/Bookings/Details/index.scss
@@ -11,13 +11,13 @@
 
 .large-image-container {
   margin: auto;
-  width: 320px;
+  width: 240px;
 }
 
 .image-container {
   height: 400px;
   margin-top: 6%;
-  width: 320px;
+  width: 240px;
   display: flex;
   flex-direction: column;
 }

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
   },
   "lint-staged": {
     "linters": {
-      ".{sass,scss}": [
+      "*.{sass,scss}": [
         "stylelint"
       ],
       "*.{js,json,css}": [


### PR DESCRIPTION
I have amended the width property for the prisoner's image in the second 'quick look' screen where the image becomes larger. 
The image previously out of proportion by being too wide. Have reduced width to 240px and applied a left margin to centre the image on the page