### PR TITLE
DT-120 use correct URL

### DIFF
--- a/app/components/ActionLinks/index.js
+++ b/app/components/ActionLinks/index.js
@@ -96,7 +96,11 @@ const ActionLinks = ({
         )}
 
         {isKeyWorkerAdmin && omicUrl && (
-          <ActionLink url={omicUrl} image="/img/manage-key-workers2x.png" testId="manage-kw-link">
+          <ActionLink
+            url={`${omicUrl}manage-key-workers`}
+            image="/img/manage-key-workers2x.png"
+            testId="manage-kw-link"
+          >
             Manage key workers
           </ActionLink>
         )}

--- a/app/components/ActionLinks/tests/index.test.js
+++ b/app/components/ActionLinks/tests/index.test.js
@@ -38,7 +38,7 @@ describe('Actions component', () => {
       />
     )
 
-    expect(wrapper.find('ActionLink').prop('url')).toBe('//omicURL')
+    expect(wrapper.find('ActionLink').prop('url')).toBe('//omicURLmanage-key-workers')
   })
 
   it('should not show anything when the user does not have any applicable roles', () => {


### PR DESCRIPTION
Don't use base URL as will re-direct to page for admin roles (if you have them)