### PR TITLE
NN-2098: Fix alert type filter position by conditionally showing error div

### DIFF
--- a/app/components/FormComponents/SelectWithLabelAndMagicAllOption/index.js
+++ b/app/components/FormComponents/SelectWithLabelAndMagicAllOption/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ErrorText from '@govuk-react/error-text'
 import { inputType, metaType } from '../../../types'
 
 class SelectWithLabelAndMagicAllOption extends Component {
@@ -26,6 +27,7 @@ class SelectWithLabelAndMagicAllOption extends Component {
       title,
       meta: { touched, error },
     } = this.props
+    const hasError = touched && error
 
     this.updateDefaulted()
 
@@ -41,8 +43,7 @@ class SelectWithLabelAndMagicAllOption extends Component {
           {title}
         </label>
 
-        <div className="error-message">{touched && (error && <span>{error}</span>)}</div>
-
+        {hasError && <ErrorText>{error}</ErrorText>}
         <select
           id={input.name}
           className={!(touched && error) ? 'form-control' : 'form-control form-control-error'}


### PR DESCRIPTION
The error div was ever-present, rather than only appearing when there's an error. Took the opportunity to make the component use the govuk react error component as well, to make future refactor easier.