### PR TITLE
CAT-562 DPS manage link should be available for everyone

### DIFF
--- a/app/containers/Bookings/Details/header.js
+++ b/app/containers/Bookings/Details/header.js
@@ -87,11 +87,19 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = (immutableState, props) => {
   const { isKeyWorker, isCatToolUser, isUseOfForce } = immutableState.getIn(['authentication', 'user']) || {}
+  const userCanEdit = immutableState.getIn(['eliteApiLoader', 'Bookings', 'Details', props.offenderNo, 'UserCanEdit'])
+  const offenderInCaseload = immutableState.getIn([
+    'eliteApiLoader',
+    'Bookings',
+    'Details',
+    props.offenderNo,
+    'OffenderInCaseload',
+  ])
   return {
     headerDetails: immutableState.getIn(['eliteApiLoader', 'Bookings', 'Details', props.offenderNo, 'Data']),
-    userCanEdit: immutableState.getIn(['eliteApiLoader', 'Bookings', 'Details', props.offenderNo, 'UserCanEdit']),
+    userCanEdit,
     showAddKeyworkerSessionLink: Boolean(isKeyWorker),
-    showCategorisationLink: Boolean(isCatToolUser),
+    showCategorisationLink: Boolean(isCatToolUser || offenderInCaseload),
     categorisationUrl: immutableState.getIn(['app', 'categorisationUrl']),
     isUseOfForce: Boolean(isUseOfForce),
     useOfForceUrl: immutableState.getIn(['app', 'useOfForceUrl']),

--- a/app/containers/EliteApiLoader/reducer.js
+++ b/app/containers/EliteApiLoader/reducer.js
@@ -219,8 +219,12 @@ function EliteApiReducer(state = initialState, action) {
       const offenderAgency = state.getIn(['Bookings', 'Details', offenderNo, 'Data', 'agencyId'])
       const caseLoad = caseloads.find(x => x.get('caseLoadId') === offenderAgency)
 
-      const userCanEdit = (canViewInactivePrisoner && ['OUT', 'TRN'].includes(offenderAgency)) || caseLoad !== undefined
-      return state.setIn(['Bookings', 'Details', offenderNo, 'UserCanEdit'], userCanEdit)
+      const offenderInCaseload = caseLoad !== undefined
+      const userCanEdit = (canViewInactivePrisoner && ['OUT', 'TRN'].includes(offenderAgency)) || offenderInCaseload
+
+      return state
+        .setIn(['Bookings', 'Details', offenderNo, 'UserCanEdit'], userCanEdit)
+        .setIn(['Bookings', 'Details', offenderNo, 'OffenderInCaseload'], offenderInCaseload)
     }
 
     default: {

--- a/app/containers/EliteApiLoader/reducer.test.js
+++ b/app/containers/EliteApiLoader/reducer.test.js
@@ -23,8 +23,10 @@ describe('EliteApiReducer reducer', () => {
       const initialState = fromJS({ User: { CaseLoads: { Data: {} } } })
       const state = eliteApiReducer(initialState, { type: CALC_READ_ONLY_VIEW, payload: { offenderNo: 'AB12345C' } })
       const userCanEdit = state.getIn(['Bookings', 'Details', 'AB12345C', 'UserCanEdit'])
+      const offenderInCaseload = state.getIn(['Bookings', 'Details', 'AB12345C', 'OffenderInCaseload'])
 
       expect(userCanEdit).toBe(false)
+      expect(offenderInCaseload).toBe(false)
     })
     it('should be able to edit if offender in case load', () => {
       const initialState = fromJS({
@@ -33,8 +35,10 @@ describe('EliteApiReducer reducer', () => {
       })
       const state = eliteApiReducer(initialState, { type: CALC_READ_ONLY_VIEW, payload: { offenderNo: 'AB12345C' } })
       const userCanEdit = state.getIn(['Bookings', 'Details', 'AB12345C', 'UserCanEdit'])
+      const offenderInCaseload = state.getIn(['Bookings', 'Details', 'AB12345C', 'OffenderInCaseload'])
 
       expect(userCanEdit).toBe(true)
+      expect(offenderInCaseload).toBe(true)
     })
     it('should be able to edit if user can view inactive bookings and prisoner out', () => {
       const initialState = fromJS({
@@ -43,8 +47,10 @@ describe('EliteApiReducer reducer', () => {
       })
       const state = eliteApiReducer(initialState, { type: CALC_READ_ONLY_VIEW, payload: { offenderNo: 'AB12345C' } })
       const userCanEdit = state.getIn(['Bookings', 'Details', 'AB12345C', 'UserCanEdit'])
+      const offenderInCaseload = state.getIn(['Bookings', 'Details', 'AB12345C', 'OffenderInCaseload'])
 
       expect(userCanEdit).toBe(true)
+      expect(offenderInCaseload).toBe(false)
     })
     it('should be able to edit if user can view inactive bookings and prisoner transfer', () => {
       const initialState = fromJS({

--- a/notm-specs/src/test/groovy/specs/OffenderDetailsSpecification.groovy
+++ b/notm-specs/src/test/groovy/specs/OffenderDetailsSpecification.groovy
@@ -84,7 +84,7 @@ class OffenderDetailsSpecification extends BrowserReportingSpec {
                                     'No visit history', 'No upcoming visits', 'Sashonda, Diydonopher', 'Social/ Family(Girlfriend)', '--']
     // todo: release date '07/04/2017' is displayed in US formaty in circle ci!
     containsExpectedIgnoringBlankAndDates(allQuicklookValues2, expectedQuicklookValues2)
-    !categorisationLink.isDisplayed()
+    categorisationLink*.text() contains 'Manage'
 
     // edit view means links shown
     addAppointmentLink.isDisplayed()
@@ -228,9 +228,9 @@ class OffenderDetailsSpecification extends BrowserReportingSpec {
     prisonHubServer.verify(WireMock.getRequestedFor(WireMock.urlPathEqualTo(iepDetailsSuffix)))
   }
 
-  def "Categorisation link is displayed for a user with a categorisation access role"() {
+  def "Categorisation link is displayed for a user with a categorisation access role but prisoner not in caseload"() {
     given: 'As a Categoriser, I log in and search for an offender'
-    fixture.loginAs(ITAG_USER, [AccessRoles.categoriser])
+    fixture.loginAs(GLOBAL_USER, [AccessRoles.categoriser])
 
     def offenders = [Offender.SMITH()]
 
@@ -242,7 +242,7 @@ class OffenderDetailsSpecification extends BrowserReportingSpec {
     elite2api.stubKeyworkerOld()
     elite2api.stubAliases()
     elite2api.stubStaffDetails(-2)
-    keyworkerApi.stubGetKeyworkerByPrisonAndOffenderNo('LEI', 'A1234AJ')
+    keyworkerApi.stubGetKeyworkerByPrisonAndOffenderNo('BXI', 'A1234AJ')
     elite2api.stubGetKeyWorker(-2, 'A1234AJ')
 
     searchFor "smith"


### PR DESCRIPTION
It should be always shown if the prisoner is in a prison in the caseload as well as if the user has a cat role. 