### PR TITLE
NN-2320 disable low severity build failures

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,5 @@
 {
-  "low": true,
+  "medium": true,
   "package-manager": "auto",
   "registry": "https://registry.npmjs.org"
 }


### PR DESCRIPTION
We have one low severity warning due to an out of date version of Webpack. The suggested fix is to upgrade to version 4, there's a ticket in the backlog to address this. 