### PR TITLE
PAT-433: Updated roles for Pathfinder to new names

### DIFF
--- a/app/containers/Authentication/reducer.js
+++ b/app/containers/Authentication/reducer.js
@@ -39,7 +39,7 @@ const CAT_ROLES = [
   'CATEGORISATION_SECURITY',
 ]
 
-const PATHFINDER_ROLES = ['PATHFINDER_PPL', 'PATHFINDER_OM', 'PATHFINDER_IC']
+const PATHFINDER_ROLES = ['PF_STD_PRISON', 'PF_STD_PROBATION', 'PF_APPROVAL', 'PF_STD_PRISON_RO', 'PF_STD_PROBATION_RO']
 
 function authenticationReducer(state = initialState, action) {
   switch (action.type) {

--- a/app/containers/Authentication/tests/reducer.test.js
+++ b/app/containers/Authentication/tests/reducer.test.js
@@ -166,10 +166,10 @@ describe('Authentication reducer', () => {
     expect(userState.canViewProbationDocuments).toBe(false)
   })
 
-  it('should return a user with access to Pathfinder links where a PATHFINDER_PPL role is present', () => {
+  it('should return a user with access to Pathfinder links where a PF_STD_PRISON role is present', () => {
     const user = {
       ...userData,
-      accessRoles: [{ roleCode: 'PATHFINDER_PPL', roleDescription: 'Prison Prevent Lead' }],
+      accessRoles: [{ roleCode: 'PF_STD_PRISON', roleDescription: 'Pathfinder standard prison' }],
     }
     const state = authenticationReducer(Map({}), userMe({ user }))
     const userState = state.get('user')
@@ -199,10 +199,10 @@ describe('Authentication reducer', () => {
     expect(userState.isPomAllocUser).toBe(true)
   })
 
-  it('should return a user with access to Pathfinder links where a PATHFINDER_OM role is present', () => {
+  it('should return a user with access to Pathfinder links where a PF_STD_PROBATION role is present', () => {
     const user = {
       ...userData,
-      accessRoles: [{ roleCode: 'PATHFINDER_OM', roleDescription: 'Offender Manager' }],
+      accessRoles: [{ roleCode: 'PF_STD_PROBATION', roleDescription: 'Pathfinder standard probation' }],
     }
     const state = authenticationReducer(Map({}), userMe({ user }))
     const userState = state.get('user')

--- a/notm-specs/src/test/groovy/mockapis/response/AccessRoles.groovy
+++ b/notm-specs/src/test/groovy/mockapis/response/AccessRoles.groovy
@@ -42,7 +42,7 @@ class AccessRoles {
 
   static def pathfinderUser = [
     roleId: 4,
-    roleCode: "PATHFINDER_PPL",
-    roleName: "Prison Prevent Lead"
+    roleCode: "PF_STD_PRISON",
+    roleName: "Pathfinder prison role"
   ]
 }


### PR DESCRIPTION
Small changes to cater for renamed pathfinder roles. 
This detects the pathfinder roles and enables links in new nomis ui to Pathfinder for users with any of these present.