### PR TITLE
DCS-531 only show covid link if prison user

### DIFF
--- a/app/components/ActionLinks/index.js
+++ b/app/components/ActionLinks/index.js
@@ -39,6 +39,7 @@ const ActionLinks = ({
   isUseOfForce,
   isPathfinderUser,
   isLicenceUser,
+  isPrisonUser,
   isPecsUser,
   pecsUrl,
   isPomAllocUser,
@@ -76,7 +77,7 @@ const ActionLinks = ({
           </ActionLink>
         )}
 
-        {prisonStaffHubUrl && (
+        {isPrisonUser && prisonStaffHubUrl && (
           <ActionLink
             url={`${prisonStaffHubUrl}current-covid-units`}
             image="/img/CovidUnits_icon.png"

--- a/app/components/ActionLinks/tests/index.test.js
+++ b/app/components/ActionLinks/tests/index.test.js
@@ -73,7 +73,13 @@ it('should show add bulk appointments link when the user has admin rights', () =
   const wrapper = mount(<ActionLinks prisonStaffHubUrl="http://" isAddBulkAppointments />)
   expect(wrapper.text()).toMatch('Add bulk appointments')
 })
-it('should show COVID link for all users', () => {
-  const wrapper = shallow(<ActionLinks prisonStaffHubUrl="http://" />)
+
+it('should show COVID link if a prison user', () => {
+  const wrapper = shallow(<ActionLinks prisonStaffHubUrl="http://" isPrisonUser />)
   expect(wrapper.find('ActionLink').prop('url')).toBe('http://current-covid-units')
+})
+
+it('should show not show COVID link if not a prison user', () => {
+  const wrapper = shallow(<ActionLinks prisonStaffHubUrl="http://" />)
+  expect(wrapper.find('ActionLink').length).toBe(0)
 })

--- a/app/containers/Authentication/reducer.js
+++ b/app/containers/Authentication/reducer.js
@@ -43,6 +43,15 @@ const PECS_ROLES = ['PECS_OCA', 'PECS_PRISON']
 
 const PATHFINDER_ROLES = ['PF_STD_PRISON', 'PF_STD_PROBATION', 'PF_APPROVAL', 'PF_STD_PRISON_RO', 'PF_STD_PROBATION_RO']
 
+const ADMIN_ROLES = [
+  'MAINTAIN_ACCESS_ROLES',
+  'MAINTAIN_ACCESS_ROLES_ADMIN',
+  'MAINTAIN_OAUTH_USERS',
+  'AUTH_GROUP_MANAGER',
+]
+
+const LICENCE_ROLES = ['NOMIS_BATCHLOAD', 'LICENCE_CA', 'LICENCE_DM', 'LICENCE_RO', 'LICENCE_VARY']
+
 function authenticationReducer(state = initialState, action) {
   switch (action.type) {
     case USER_ME: {
@@ -50,73 +59,25 @@ function authenticationReducer(state = initialState, action) {
 
       window.currentCaseLoadId = user.activeCaseLoadId
 
-      const isKeyWorkerAdmin = Boolean(
-        user.accessRoles &&
-          user.accessRoles.some(r => r.roleCode === 'OMIC_ADMIN' || r.roleCode === 'KEYWORKER_MONITOR')
-      )
-      const isCatToolUser = Boolean(user.accessRoles && user.accessRoles.some(r => CAT_ROLES.includes(r.roleCode)))
-
-      const isPathfinderUser = Boolean(
-        user.accessRoles && user.accessRoles.some(r => PATHFINDER_ROLES.includes(r.roleCode))
-      )
+      const hasRoleIn = roles => Boolean(user.accessRoles && user.accessRoles.some(r => roles.includes(r.roleCode)))
 
       const isKeyWorker = Boolean(user.staffRoles && user.staffRoles.some(r => r.role === 'KW'))
 
-      const isPomAllocUser = Boolean(
-        user.accessRoles && user.accessRoles.some(r => r.roleCode === 'ALLOC_MGR' || r.roleCode === 'ALLOC_CASE_MGR')
-      )
-
-      const isLicenceUser = Boolean(
-        user.accessRoles &&
-          user.accessRoles.some(
-            r =>
-              r.roleCode === 'NOMIS_BATCHLOAD' ||
-              r.roleCode === 'LICENCE_CA' ||
-              r.roleCode === 'LICENCE_DM' ||
-              r.roleCode === 'LICENCE_RO' ||
-              r.roleCode === 'LICENCE_VARY'
-          )
-      )
-
-      const isPecsUser = Boolean(user.accessRoles && user.accessRoles.some(r => PECS_ROLES.includes(r.roleCode)))
-
-      const canGlobalSearch = Boolean(user.accessRoles && user.accessRoles.some(r => r.roleCode === 'GLOBAL_SEARCH'))
-
-      const canAddBulkAppointments = Boolean(
-        user.accessRoles && user.accessRoles.some(r => r.roleCode === 'BULK_APPOINTMENTS')
-      )
-
-      const hasAdminRights = Boolean(
-        user.accessRoles &&
-          user.accessRoles.some(
-            r =>
-              r.roleCode === 'MAINTAIN_ACCESS_ROLES' ||
-              r.roleCode === 'MAINTAIN_ACCESS_ROLES_ADMIN' ||
-              r.roleCode === 'MAINTAIN_OAUTH_USERS' ||
-              r.roleCode === 'AUTH_GROUP_MANAGER'
-          )
-      )
-
-      const canUpdateAlerts = Boolean(user.accessRoles && user.accessRoles.some(r => r.roleCode === 'UPDATE_ALERT'))
-      const canViewProbationDocuments = Boolean(
-        user.accessRoles &&
-          user.accessRoles.some(r => r.roleCode === 'VIEW_PROBATION_DOCUMENTS' || r.roleCode === 'POM')
-      )
-
       return state.set('user', {
-        hasAdminRights,
-        isKeyWorkerAdmin,
+        hasAdminRights: hasRoleIn(ADMIN_ROLES),
+        isKeyWorkerAdmin: hasRoleIn(['OMIC_ADMIN', 'KEYWORKER_MONITOR']),
         isKeyWorker,
-        canGlobalSearch,
-        canAddBulkAppointments,
+        canGlobalSearch: hasRoleIn(['GLOBAL_SEARCH']),
+        canAddBulkAppointments: hasRoleIn(['BULK_APPOINTMENTS']),
         ...action.payload.user,
-        isCatToolUser,
-        canUpdateAlerts,
-        canViewProbationDocuments,
-        isPathfinderUser,
-        isLicenceUser,
-        isPecsUser,
-        isPomAllocUser,
+        isCatToolUser: hasRoleIn(CAT_ROLES),
+        canUpdateAlerts: hasRoleIn(['UPDATE_ALERT']),
+        canViewProbationDocuments: hasRoleIn(['VIEW_PROBATION_DOCUMENTS', 'POM']),
+        isPathfinderUser: hasRoleIn(PATHFINDER_ROLES),
+        isLicenceUser: hasRoleIn(LICENCE_ROLES),
+        isPecsUser: hasRoleIn(PECS_ROLES),
+        isPomAllocUser: hasRoleIn(['ALLOC_MGR', 'ALLOC_CASE_MGR']),
+        isPrisonUser: hasRoleIn(['PRISON']),
       })
     }
 

--- a/app/containers/Authentication/tests/reducer.test.js
+++ b/app/containers/Authentication/tests/reducer.test.js
@@ -175,6 +175,17 @@ describe('Authentication reducer', () => {
     expect(userState.canViewProbationDocuments).toBe(false)
   })
 
+  it('should return a user that is a prison user if they have the PRISON role', () => {
+    const user = {
+      ...userData,
+      accessRoles: [{ roleCode: 'PRISON', roleDescription: 'View probation documents' }],
+    }
+    const state = authenticationReducer(Map({}), userMe({ user }))
+    const userState = state.get('user')
+
+    expect(userState.isPrisonUser).toBe(true)
+  })
+
   it('should return a user with access to Pathfinder links where a PF_STD_PRISON role is present', () => {
     const user = {
       ...userData,

--- a/app/containers/HomePage/index.js
+++ b/app/containers/HomePage/index.js
@@ -63,6 +63,7 @@ class HomePage extends Component {
               licencesUrl={licencesUrl}
               isLicenceUser={user.isLicenceUser}
               isPecsUser={user.isPecsUser}
+              isPrisonUser={user.isPrisonUser}
             />
           </div>
         </Page>

--- a/notm-specs/src/test/groovy/mockapis/response/AccessRoles.groovy
+++ b/notm-specs/src/test/groovy/mockapis/response/AccessRoles.groovy
@@ -22,6 +22,13 @@ class AccessRoles {
     caseloadId: "LEI"
   ]
 
+  static def prison = [
+    roleId: 0,
+    roleCode: "PRISON",
+    roleName: "Prison role",
+    parentRoleCode: "code",
+  ]
+
   static def addBulkAppointments = [
           roleId: 1,
     roleCode: 'BULK_APPOINTMENTS',

--- a/notm-specs/src/test/groovy/specs/HomePageSpecification.groovy
+++ b/notm-specs/src/test/groovy/specs/HomePageSpecification.groovy
@@ -6,6 +6,7 @@ import mockapis.Elite2Api
 import mockapis.KeyworkerApi
 import mockapis.OauthApi
 import mockapis.WhereaboutsApi
+import mockapis.response.AccessRoles
 import model.TestFixture
 import model.UserAccount
 import org.junit.Rule
@@ -41,7 +42,7 @@ class HomePageSpecification extends BrowserReportingSpec {
 
   def "should show the View COVID units link to every user role"() {
     given: "the user is logged in"
-    fixture.loginAs(UserAccount.ITAG_USER)
+    fixture.loginAs(UserAccount.ITAG_USER, [AccessRoles.prison])
 
     when: 'I am on the homepage'
     at HomePage


### PR DESCRIPTION
Currently showing covid unit link to probation users. These users don't have access to prison caseloads so currently can't see any information related to covid but nevertheless they  shouldn't be able to see the link