### PR TITLE
DT-943-use-new-keyworker-url

### DIFF
--- a/app/components/ActionLinks/index.js
+++ b/app/components/ActionLinks/index.js
@@ -61,7 +61,7 @@ const ActionLinks = ({
 
         {isKeyWorker && omicUrl && (
           <ActionLink
-            url={`${omicUrl}manage-key-workers/key-worker/${staffId}`}
+            url={`${omicUrl}key-worker/${staffId}`}
             image="/img/ICON_MyKeyWorkerAssignments@2x.png"
             testId="my-kw-allocations-link"
           >
@@ -128,11 +128,7 @@ const ActionLinks = ({
         )}
 
         {isKeyWorkerAdmin && omicUrl && (
-          <ActionLink
-            url={`${omicUrl}manage-key-workers`}
-            image="/img/ICON_ManageKeyWorkers.png"
-            testId="manage-kw-link"
-          >
+          <ActionLink url={`${omicUrl}`} image="/img/ICON_ManageKeyWorkers.png" testId="manage-kw-link">
             Manage key workers
           </ActionLink>
         )}

--- a/app/components/ActionLinks/tests/index.test.js
+++ b/app/components/ActionLinks/tests/index.test.js
@@ -8,13 +8,13 @@ describe('Actions component', () => {
   it('should only show the my allocations link when the user is a key worker', () => {
     const wrapper = shallow(<ActionLinks omicUrl="http://manage-key-workers/" staffId="123" isKeyWorker />)
 
-    expect(wrapper.find('ActionLink').prop('url')).toBe('http://manage-key-workers/manage-key-workers/key-worker/123')
+    expect(wrapper.find('ActionLink').prop('url')).toBe('http://manage-key-workers/key-worker/123')
   })
 
   it('should only show the key worker admin link when the user is a key worker admin', () => {
     const wrapper = shallow(<ActionLinks omicUrl="http://manage-key-workers/" isKeyWorkerAdmin />)
 
-    expect(wrapper.find('ActionLink').prop('url')).toBe('http://manage-key-workers/manage-key-workers')
+    expect(wrapper.find('ActionLink').prop('url')).toBe('http://manage-key-workers/')
   })
 
   it('should show admin and utilities link when the user has admin rights', () => {

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -23,7 +23,7 @@ const HmppsHeader = ({ user, menuOpen, setMenuOpen, extraLinks, omicUrl }) => {
   if (user && user.isKeyWorker) {
     extraLinks.push({
       text: 'My key worker allocations',
-      url: `${omicUrl}manage-key-workers/key-worker/${user.staffId}`,
+      url: `${omicUrl}key-worker/${user.staffId}`,
     })
   }
 

--- a/server/setupRoutes.js
+++ b/server/setupRoutes.js
@@ -95,7 +95,7 @@ module.exports = ({
   router.use('/key-worker-allocations', async (req, res) => {
     const user = await userService.me(res.locals)
     const omicUrl = config.apis.keyworker.ui_url
-    res.redirect(301, `${omicUrl}manage-key-workers/key-worker/${user.userId}`)
+    res.redirect(301, `${omicUrl}key-worker/${user.userId}`)
   })
 
   // Forward requests to the eliteApi get/post functions.


### PR DESCRIPTION
This depends upon manage-key-worker version 2020-06-23.4295.93d5a1d (currently in circle pipeline [#239](https://app.circleci.com/pipelines/github/ministryofjustice/manage-key-workers/239/)).